### PR TITLE
Connection pool support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+cache: bundler
+bundler_args: --without development deploy optional
 
 jdk:
   - oraclejdk7
@@ -13,7 +15,7 @@ rvm:
   - jruby-19mode
   - rbx-19mode
   - rbx-2.5.3
-  
+
 matrix:
   allow_failures:
     - rvm: rbx-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-bundler_args: --without development deploy optional
+bundler_args: --without optional
 
 jdk:
   - oraclejdk7

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :optional, :development do
+  gem 'guard-rspec'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-group :optional, :development do
+group :optional do
   gem 'guard-rspec'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,39 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features)
+
+## Uncomment to clear the screen before every task
+# clearing :on
+
+## Guard internally checks for changes in the Guardfile and exits.
+## If you want Guard to automatically start up again, run guard in a
+## shell loop, e.g.:
+##
+##  $ while bundle exec guard; do echo "Restarting Guard..."; done
+##
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rsspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separetly)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: 'bundle exec rspec' do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+end

--- a/lib/mordor/config.rb
+++ b/lib/mordor/config.rb
@@ -62,6 +62,7 @@ module Mordor
           :database => 'development',
           :pool_size => 5,
           :pool_timeout => 1,
+          :rs_refresh_mode => :sync,
         }
       end
 

--- a/lib/mordor/config.rb
+++ b/lib/mordor/config.rb
@@ -59,7 +59,9 @@ module Mordor
         @defaults ||= {
           :hostname => 'localhost',
           :port     => 27017,
-          :database => 'development'
+          :database => 'development',
+          :pool_size => 5,
+          :pool_timeout => 1,
         }
       end
 

--- a/lib/mordor/config.rb
+++ b/lib/mordor/config.rb
@@ -23,6 +23,12 @@ module Mordor
         nil
       end
 
+      # Resets the configuration to its default state
+      #
+      def reset
+        setup
+      end
+
       # Retrieve the value of a config entry.
       #
       # ==== Parameters

--- a/lib/mordor/config.rb
+++ b/lib/mordor/config.rb
@@ -18,7 +18,7 @@ module Mordor
       #
       # :api: publicdef use
       def use
-        @configuration ||= {}
+        @configuration ||= defaults
         yield @configuration
         nil
       end
@@ -60,8 +60,8 @@ module Mordor
           :hostname => 'localhost',
           :port     => 27017,
           :database => 'development',
-          :pool_size => 5,
-          :pool_timeout => 1,
+          :pool_size => nil,
+          :pool_timeout => nil,
           :rs_refresh_mode => :sync,
         }
       end

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -323,7 +323,7 @@ module Mordor
       end
 
       def replica_set_options
-        pool_options.tap do |options|
+        Hash.new.tap do |options|
           options[:refresh_mode] = Mordor::Config[:rs_refresh_mode]
           options[:rs_name] = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
         end
@@ -337,12 +337,24 @@ module Mordor
         replica_set_host_list.size > 1
       end
 
+      # Connection setup
+
       def new_mongo_connection
-        Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port], pool_options)
+        Mongo::Connection.new(*mongo_connection_args)
       end
 
       def new_replica_set_client
-        Mongo::MongoReplicaSetClient.new(replica_set_host_list, replica_set_options)
+        Mongo::MongoReplicaSetClient.new(*replica_set_client_args)
+      end
+
+      # Connection arguments
+
+      def mongo_connection_args
+        [ Mordor::Config[:hostname], Mordor::Config[:port] ]
+      end
+
+      def replica_set_client_args
+        [ replica_set_host_list, replica_set_options ]
       end
 
     end

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -318,16 +318,7 @@ module Mordor
         date_range_to_query( day_to_range(day) )
       end
 
-      def pool_options
-        {:pool_size => Mordor::Config[:pool_size], :pool_timeout => Mordor::Config[:pool_timeout]}
-      end
-
-      def replica_set_options
-        Hash.new.tap do |options|
-          options[:refresh_mode] = Mordor::Config[:rs_refresh_mode]
-          options[:rs_name] = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
-        end
-      end
+      # Replica set helpers
 
       def replica_set_host_list
         @replica_set_hosts ||= Mordor::Config[:hostname].split(',').map(&:strip)
@@ -350,11 +341,29 @@ module Mordor
       # Connection arguments
 
       def mongo_connection_args
-        [ Mordor::Config[:hostname], Mordor::Config[:port] ]
+        [ Mordor::Config[:hostname], Mordor::Config[:port] ].tap do |args|
+          args << pool_options unless pool_options.empty?
+        end
       end
 
       def replica_set_client_args
         [ replica_set_host_list, replica_set_options ]
+      end
+
+      # Connection options
+
+      def pool_options
+        @pool_options ||= Hash.new.tap do |options|
+          options[:pool_size]    = Mordor::Config[:pool_size]    if Mordor::Config[:pool_size]
+          options[:pool_timeout] = Mordor::Config[:pool_timeout] if Mordor::Config[:pool_timeout]
+        end
+      end
+
+      def replica_set_options
+        @replica_set_options ||= pool_options.tap do |options|
+          options[:refresh_mode] = Mordor::Config[:rs_refresh_mode]
+          options[:rs_name]      = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
+        end
       end
 
     end

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -337,7 +337,7 @@ module Mordor
 
       def mongo_connection_args
         [ Mordor::Config[:hostname], Mordor::Config[:port] ].tap do |args|
-          args << pool_options if pool_options.any?
+          args << connection_pool_options if connection_pool_options.any?
         end.compact
       end
 
@@ -353,17 +353,17 @@ module Mordor
 
       # Connection options
 
-      def pool_options
-        @pool_options ||= Hash.new.tap do |options|
-          options[:pool_size]    = Mordor::Config[:pool_size]    if Mordor::Config[:pool_size]
-          options[:pool_timeout] = Mordor::Config[:pool_timeout] if Mordor::Config[:pool_timeout]
+      def connection_pool_options
+        @connection_pool_options ||= Hash.new.tap do |hash|
+          hash[:pool_size]    = Mordor::Config[:pool_size]    if Mordor::Config[:pool_size]
+          hash[:pool_timeout] = Mordor::Config[:pool_timeout] if Mordor::Config[:pool_timeout]
         end
       end
 
       def replica_set_options
-        @replica_set_options ||= pool_options.tap do |options|
-          options[:refresh_mode] = Mordor::Config[:rs_refresh_mode]
-          options[:rs_name]      = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
+        @replica_set_options ||= connection_pool_options.tap do |hash|
+          hash[:refresh_mode] = Mordor::Config[:rs_refresh_mode]
+          hash[:rs_name]      = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
         end
       end
 

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -173,9 +173,9 @@ module Mordor
       def database
         unless @db
           if connecting_to_replica_set?
-            connection = Mongo::MongoReplicaSetClient.new(replica_set_host_list, replica_set_options)
+            connection = new_replica_set_client
           else
-            connection = Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port], pool_options)
+            connection = new_mongo_connection
           end
           @db = connection.db(Mordor::Config[:database])
           @db.authenticate(Mordor::Config[:username], Mordor::Config[:password]) if Mordor::Config[:username]
@@ -263,7 +263,8 @@ module Mordor
         EOS
       end
 
-      private
+    private
+
       def perform_collection_find(query, options = {})
         ensure_indices
         collection.find(query, options)
@@ -334,6 +335,14 @@ module Mordor
 
       def connecting_to_replica_set?
         replica_set_host_list.size > 1
+      end
+
+      def new_mongo_connection
+        Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port], pool_options)
+      end
+
+      def new_replica_set_client
+        Mongo::MongoReplicaSetClient.new(replica_set_host_list, replica_set_options)
       end
 
     end

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -173,9 +173,7 @@ module Mordor
       def database
         unless @db
           if connecting_to_replica_set?
-            hosts = replica_set_host_list
-            options = replica_set_options
-            connection = Mongo::MongoReplicaSetClient.new(hosts, options)
+            connection = Mongo::MongoReplicaSetClient.new(replica_set_host_list, replica_set_options)
           else
             connection = Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port], pool_options)
           end

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -172,7 +172,8 @@ module Mordor
 
       def database
         unless @db
-          if (hosts = Mordor::Config[:hostname].split(",").map{|h| h.strip}).size > 1
+          if connecting_to_replica_set?
+            hosts = replica_set_host_list
             options = pool_options.merge({:refresh_mode => :sync})
             options[:rs_name] = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
             connection = Mongo::MongoReplicaSetClient.new(hosts, options)
@@ -322,7 +323,15 @@ module Mordor
       def pool_options
         {:pool_size => Mordor::Config[:pool_size], :pool_timeout => Mordor::Config[:pool_timeout]}
       end
-      
+
+      def replica_set_host_list
+        @replica_set_hosts ||= Mordor::Config[:hostname].split(',').map(&:strip)
+      end
+
+      def connecting_to_replica_set?
+        replica_set_host_list.size > 1
+      end
+
     end
   end
 end

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -173,11 +173,11 @@ module Mordor
       def database
         unless @db
           if (hosts = Mordor::Config[:hostname].split(",").map{|h| h.strip}).size > 1
-            options = {:refresh_mode => :sync}
+            options = {:refresh_mode => :sync, :pool_size => Mordor::Config[:pool_size], :pool_timeout => Mordor::Config[:pool_timeout]}
             options[:rs_name] = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
             connection = Mongo::MongoReplicaSetClient.new(hosts, options)
           else
-            connection = Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port])
+            connection = Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port], :pool_size => Mordor::Config[:pool_size], :pool_timeout => Mordor::Config[:pool_timeout])
           end
           @db = connection.db(Mordor::Config[:database])
           @db.authenticate(Mordor::Config[:username], Mordor::Config[:password]) if Mordor::Config[:username]

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -173,11 +173,11 @@ module Mordor
       def database
         unless @db
           if (hosts = Mordor::Config[:hostname].split(",").map{|h| h.strip}).size > 1
-            options = {:refresh_mode => :sync, :pool_size => Mordor::Config[:pool_size], :pool_timeout => Mordor::Config[:pool_timeout]}
+            options = pool_options.merge({:refresh_mode => :sync})
             options[:rs_name] = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
             connection = Mongo::MongoReplicaSetClient.new(hosts, options)
           else
-            connection = Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port], :pool_size => Mordor::Config[:pool_size], :pool_timeout => Mordor::Config[:pool_timeout])
+            connection = Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port], pool_options)
           end
           @db = connection.db(Mordor::Config[:database])
           @db.authenticate(Mordor::Config[:username], Mordor::Config[:password]) if Mordor::Config[:username]
@@ -318,6 +318,11 @@ module Mordor
       def day_to_query(day)
         date_range_to_query( day_to_range(day) )
       end
+
+      def pool_options
+        {:pool_size => Mordor::Config[:pool_size], :pool_timeout => Mordor::Config[:pool_timeout]}
+      end
+      
     end
   end
 end

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -174,8 +174,7 @@ module Mordor
         unless @db
           if connecting_to_replica_set?
             hosts = replica_set_host_list
-            options = pool_options.merge({:refresh_mode => :sync})
-            options[:rs_name] = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
+            options = replica_set_options
             connection = Mongo::MongoReplicaSetClient.new(hosts, options)
           else
             connection = Mongo::Connection.new(Mordor::Config[:hostname], Mordor::Config[:port], pool_options)
@@ -322,6 +321,13 @@ module Mordor
 
       def pool_options
         {:pool_size => Mordor::Config[:pool_size], :pool_timeout => Mordor::Config[:pool_timeout]}
+      end
+
+      def replica_set_options
+        pool_options.tap do |options|
+          options[:refresh_mode] = Mordor::Config[:rs_refresh_mode]
+          options[:rs_name] = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
+        end
       end
 
       def replica_set_host_list

--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -173,12 +173,11 @@ module Mordor
       def database
         unless @db
           if connecting_to_replica_set?
-            connection = new_replica_set_client
+            client = new_replica_set_client
           else
-            connection = new_mongo_connection
+            client = new_mongo_connection
           end
-          @db = connection.db(Mordor::Config[:database])
-          @db.authenticate(Mordor::Config[:username], Mordor::Config[:password]) if Mordor::Config[:username]
+          @db = database_connection(client)
         end
 
         @db
@@ -318,16 +317,6 @@ module Mordor
         date_range_to_query( day_to_range(day) )
       end
 
-      # Replica set helpers
-
-      def replica_set_host_list
-        @replica_set_hosts ||= Mordor::Config[:hostname].split(',').map(&:strip)
-      end
-
-      def connecting_to_replica_set?
-        replica_set_host_list.size > 1
-      end
-
       # Connection setup
 
       def new_mongo_connection
@@ -338,16 +327,28 @@ module Mordor
         Mongo::MongoReplicaSetClient.new(*replica_set_client_args)
       end
 
+      def database_connection(client)
+        client.db(Mordor::Config[:database]).tap do |db|
+          db.authenticate(*authentication_args) if authentication_args.any?
+        end
+      end
+
       # Connection arguments
 
       def mongo_connection_args
         [ Mordor::Config[:hostname], Mordor::Config[:port] ].tap do |args|
-          args << pool_options unless pool_options.empty?
-        end
+          args << pool_options if pool_options.any?
+        end.compact
       end
 
       def replica_set_client_args
         [ replica_set_host_list, replica_set_options ]
+      end
+
+      def authentication_args
+        [ Mordor::Config[:username] ].tap do |args|
+          args << Mordor::Config[:password] if Mordor::Config[:password] && args.any?
+        end.compact
       end
 
       # Connection options
@@ -364,6 +365,16 @@ module Mordor
           options[:refresh_mode] = Mordor::Config[:rs_refresh_mode]
           options[:rs_name]      = Mordor::Config[:replica_set] if Mordor::Config[:replica_set]
         end
+      end
+
+      # Replica set helpers
+
+      def replica_set_host_list
+        @replica_set_hosts ||= Mordor::Config[:hostname].split(',').map(&:strip).compact
+      end
+
+      def connecting_to_replica_set?
+        replica_set_host_list.size > 1
       end
 
     end

--- a/mordor.gemspec
+++ b/mordor.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'extlib'
   s.add_runtime_dependency 'json'
-  s.add_runtime_dependency 'mongo'
+  s.add_runtime_dependency 'mongo', '< 2.0'
 
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake'

--- a/mordor.gemspec
+++ b/mordor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.0', '< 2.99'
-  
+
   s.add_runtime_dependency 'bson_ext' unless RUBY_PLATFORM == "java"
   s.extensions << 'ext/mkrf_conf.rb'
 

--- a/spec/mordor/collection_spec.rb
+++ b/spec/mordor/collection_spec.rb
@@ -19,7 +19,7 @@ describe "with respect to collections" do
     before :each do
       5.times do |index|
         res = TestResource.new(:first => "#{index}_first", :second => "#{index}_second", :third => "#{index}_third")
-        res.save.should be_true
+        res.save.should be true
       end
     end
 
@@ -40,7 +40,7 @@ describe "with respect to collections" do
     before :each do
       5.times do |index|
         res = TestResource.new(:first => "#{index}_first", :second => "#{index}_second", :third => "#{index}_third")
-        res.save.should be_true
+        res.save.should be true
       end
     end
 
@@ -78,7 +78,7 @@ describe "with respect to collections" do
     before :each do
       5.times do |index|
         res = TestResource.new(:first => "#{index}_first", :second => "#{index}_second", :third => "#{index}_third")
-        res.save.should be_true
+        res.save.should be true
       end
     end
 

--- a/spec/mordor/connection_spec.rb
+++ b/spec/mordor/connection_spec.rb
@@ -7,15 +7,17 @@ describe "connecting to mongo" do
     end
   end
 
-  it "should have a mongo database " do
-    TestResource.database.should be_instance_of(Mongo::DB)
-  end
+  describe 'database connection' do
+    it "should have a mongo database " do
+      TestResource.database.should be_instance_of(Mongo::DB)
+    end
 
-  it "should select the correct database" do
-    database_name = "any_database_name"
-    Mordor::Config.use { |config| config[:database] = database_name }
+    it "should select the correct database" do
+      database_name = "any_database_name"
+      Mordor::Config.use { |config| config[:database] = database_name }
 
-    TestResource.database.name.should == database_name
+      TestResource.database.name.should == database_name
+    end
   end
 
   describe "when credentials are provided" do

--- a/spec/mordor/connection_spec.rb
+++ b/spec/mordor/connection_spec.rb
@@ -91,5 +91,41 @@ describe "connecting to mongo" do
 
       Mongo::MongoReplicaSetClient.should_receive(:new).with(anything, options).and_return(@mock_connection)
     end
+
+    it "creates a mongo replica set client with specific pool size, if given" do
+      Mordor::Config.use do |config|
+        config[:hostname] = host_string
+        config[:pool_size] = 1
+      end
+
+      options = {:pool_size => 1, :refresh_mode => :sync}
+
+      Mongo::MongoReplicaSetClient.should_receive(:new).with(anything, options).and_return(@mock_connection)
+    end
+
+    it "creates a mongo replica set client with specific pool timeout, if given" do
+      Mordor::Config.use do |config|
+        config[:hostname] = host_string
+        config[:pool_timeout] = 1
+      end
+
+      options = {:pool_timeout => 1, :refresh_mode => :sync}
+
+      Mongo::MongoReplicaSetClient.should_receive(:new).with(anything, options).and_return(@mock_connection)
+    end
+
+    it "creates a mongo replica set client with specific pool timeout and size" do
+      Mordor::Config.use do |config|
+        config[:hostname] = host_string
+        config[:pool_size] = 5
+        config[:pool_timeout] = 1
+        config[:replica_set] = replica_set_string
+      end
+
+      options = {:pool_size => 5, :pool_timeout => 1, :refresh_mode => :sync, :rs_name => replica_set_string}
+
+      Mongo::MongoReplicaSetClient.should_receive(:new).with(anything, options).and_return(@mock_connection)
+    end
+
   end
 end

--- a/spec/mordor/connection_spec.rb
+++ b/spec/mordor/connection_spec.rb
@@ -67,31 +67,29 @@ describe "connecting to mongo" do
       Mordor::Config.reset
     end
 
-    it "creates a mongo replica set client when multiple hosts are provided" do
-      hosts = "localhost:27017, localhost:27018  "
-      hosts_array = hosts.split(",").map{ |h| h.strip }
-
-      Mordor::Config.use { |config| config[:hostname] = hosts }
-
-      Mongo::MongoReplicaSetClient.should_receive(:new).with(hosts_array, anything).and_return(@mock_connection)
-
+    after :each do
       TestResource.database
     end
 
-    it "creates a mongo replica set client with the correct replica set name if given" do
-      hosts = "localhost:27017, localhost:27018  "
-      replica_set = "sample replica set"
+    let(:host_string){ "localhost:27017, localhost:27018  " }
+    let(:replica_set_string){ "sample replica set" }
 
+    it "creates a mongo replica set client when multiple hosts are provided" do
+      hosts_array = host_string.split(",").map{ |h| h.strip }
+      Mordor::Config.use { |config| config[:hostname] = host_string }
+
+      Mongo::MongoReplicaSetClient.should_receive(:new).with(hosts_array, anything).and_return(@mock_connection)
+    end
+
+    it "creates a mongo replica set client with the correct replica set name if given" do
       Mordor::Config.use do |config|
-        config[:hostname] = hosts
-        config[:replica_set] = replica_set
+        config[:hostname] = host_string
+        config[:replica_set] = replica_set_string
       end
 
-      options = {:rs_name => replica_set, :refresh_mode => :sync}
+      options = {:rs_name => replica_set_string, :refresh_mode => :sync}
 
       Mongo::MongoReplicaSetClient.should_receive(:new).with(anything, options).and_return(@mock_connection)
-
-      TestResource.database
     end
   end
 end

--- a/spec/mordor/connection_spec.rb
+++ b/spec/mordor/connection_spec.rb
@@ -64,7 +64,6 @@ describe "connecting to mongo" do
   describe "replica sets" do
     before :each do
       @mock_connection = mock("connection", :db => mock("db"))
-      Mordor::Config.reset
     end
 
     after :each do

--- a/spec/mordor/connection_spec.rb
+++ b/spec/mordor/connection_spec.rb
@@ -64,6 +64,7 @@ describe "connecting to mongo" do
   describe "replica sets" do
     before :each do
       @mock_connection = mock("connection", :db => mock("db"))
+      Mordor::Config.reset
     end
 
     it "creates a mongo replica set client when multiple hosts are provided" do

--- a/spec/mordor/connection_spec.rb
+++ b/spec/mordor/connection_spec.rb
@@ -27,8 +27,8 @@ describe "connecting to mongo" do
         config[:password] = credentials[:password]
       end
 
-      @mock_db = mock("db")
-      Mongo::Connection.stub(:new).and_return(mock("connection", :db => @mock_db))
+      @mock_db = double("db")
+      Mongo::Connection.stub(:new).and_return(double("connection", :db => @mock_db))
     end
 
     it "should authenticate with username and password" do
@@ -39,7 +39,7 @@ describe "connecting to mongo" do
 
   describe "the Mongo database connection" do
     before :each do
-      @mock_connection = mock("connection", :db => mock("db"))
+      @mock_connection = double("connection", :db => double("db"))
     end
 
     it "should connect with specified host" do
@@ -63,7 +63,7 @@ describe "connecting to mongo" do
 
   describe "replica sets" do
     before :each do
-      @mock_connection = mock("connection", :db => mock("db"))
+      @mock_connection = double("connection", :db => double("db"))
     end
 
     after :each do

--- a/spec/mordor/connection_spec.rb
+++ b/spec/mordor/connection_spec.rb
@@ -60,6 +60,24 @@ describe "connecting to mongo" do
       Mongo::Connection.should_receive(:new).with(anything, port).and_return(@mock_connection)
     end
 
+    describe 'setting connection pool options' do
+      it 'supports setting pool size' do
+        Mordor::Config.use { |config| config[:pool_size] = 7 }
+        Mongo::Connection.should_receive(:new).with('localhost', 27017, pool_size: 7).and_return(@mock_connection)
+      end
+
+      it 'supports setting pool timeout' do
+        Mordor::Config.use { |config| config[:pool_timeout] = 8 }
+        Mongo::Connection.should_receive(:new).with('localhost', 27017, pool_timeout: 8).and_return(@mock_connection)
+      end
+
+      it 'supports setting both' do
+        Mordor::Config.use { |config|
+          config[:pool_size] = 9
+          config[:pool_timeout] = 10
+        }
+        Mongo::Connection.should_receive(:new).with('localhost', 27017, pool_size: 9, pool_timeout: 10).and_return(@mock_connection)
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,13 +15,7 @@ RSpec.configure do |config|
 end
 
 def reset_mordor_config
-  Mordor::Config.use do |config|
-    config[:username] = nil
-    config[:password] = nil
-    config[:hostname] = '127.0.0.1'
-    config[:port] = 27017
-    config[:database] = 'test'
-  end
+  Mordor::Config.reset
 end
 
 def drop_db_collections

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,5 +45,3 @@ end
 def test_class_names
   [:TestResource, :TestResource2, :TestTimedResource]
 end
-
-


### PR DESCRIPTION
- Adds support for connection pooling
- Removes support for MRI < 1.9.3 and JRuby 1.8
- Makes dependence on mongo < 2.0 explicit