### PR TITLE
Do not ensure indices upon file read

### DIFF
--- a/lib/mordor/resource.rb
+++ b/lib/mordor/resource.rb
@@ -235,7 +235,6 @@ module Mordor
         if options[:index]
           @indices    << name unless @indices.include?(name)
           @index_types[name] = options[:index_type] ? options[:index_type] : Mongo::DESCENDING
-          ensure_index(name)
         end
 
         if options[:timestamp]

--- a/spec/mordor/resource_spec.rb
+++ b/spec/mordor/resource_spec.rb
@@ -249,12 +249,12 @@ describe "with respect to resources" do
       TestResource.ensure_count.should == 2  # For each index
     end
 
-    it "should call ensure index for each index attribute on creation" do
+    it "should not call ensure index for each index attribute on file eval" do
       TestResource2.class_eval do
         attribute :test_attribute, :index => true
       end
 
-      TestResource2.ensure_count.should == 1
+      TestResource2.ensure_count.should == 0
     end
   end
 


### PR DESCRIPTION
Upon find / destroy the indices are still ensured.

I removed this because it made a mongo connection upon loading files; preventing us from booting the application in a containerized environment.